### PR TITLE
Workaround file read timeouts in injector during create_rekall_profile

### DIFF
--- a/src/libinjector/win/methods/win_createproc.c
+++ b/src/libinjector/win/methods/win_createproc.c
@@ -201,13 +201,6 @@ event_response_t handle_createproc(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             return override_step(injector, STEP4, VMI_EVENT_RESPONSE_SET_REGISTERS);
             break;
         }
-        case STEP5: // cleanup
-        {
-            drakvuf_remove_trap(drakvuf, info->trap, NULL);
-            drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
-            break;
-        }
         default:
         {
             PRINT_DEBUG("Should not be here\n");
@@ -220,13 +213,18 @@ event_response_t handle_createproc(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
 {
+    drakvuf_t drakvuf = injector->drakvuf;
+
     fprintf(stderr, "Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)
         injector->rc = INJECTOR_FAILED;
 
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP5, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 

--- a/src/libinjector/win/methods/win_read_file.c
+++ b/src/libinjector/win/methods/win_read_file.c
@@ -255,19 +255,14 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
             if (is_fun_error(drakvuf, info, "Could not close File handle"))
                 return cleanup(injector, info);
 
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-
             PRINT_DEBUG("File operation executed OK\n");
             injector->rc = INJECTOR_SUCCEEDED;
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP8: // exit loop
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -282,9 +277,15 @@ event_response_t handle_readfile_x64(drakvuf_t drakvuf, drakvuf_trap_info_t* inf
 
 static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
 {
+    drakvuf_t drakvuf = injector->drakvuf;
+
     PRINT_DEBUG("Exiting prematurely\n");
+
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP8, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 static bool process_read_file(drakvuf_t drakvuf, drakvuf_trap_info_t* info, uint32_t* num_bytes)

--- a/src/libinjector/win/methods/win_shellcode.c
+++ b/src/libinjector/win/methods/win_shellcode.c
@@ -162,15 +162,11 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
             PRINT_DEBUG("Shellcode executed\n");
             injector->rc = INJECTOR_SUCCEEDED;
 
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP5:
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -185,13 +181,18 @@ event_response_t handle_win_shellcode(drakvuf_t drakvuf, drakvuf_trap_info_t* in
 
 static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
 {
+    drakvuf_t drakvuf = injector->drakvuf;
+
     fprintf(stderr, "Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)
         injector->rc = INJECTOR_FAILED;
 
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP5, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 static bool write_payload_to_guest_memory(drakvuf_t drakvuf, drakvuf_trap_info_t* info)

--- a/src/libinjector/win/methods/win_shellexec.c
+++ b/src/libinjector/win/methods/win_shellexec.c
@@ -141,16 +141,12 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             PRINT_DEBUG("ShellExecute successful\n");
 
             injector->rc = INJECTOR_SUCCEEDED;
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP3:
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -165,11 +161,16 @@ event_response_t handle_shellexec(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
 {
+    drakvuf_t drakvuf = injector->drakvuf;
+
     fprintf(stderr, "Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)
         injector->rc = INJECTOR_FAILED;
 
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP3, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }

--- a/src/libinjector/win/methods/win_terminate.c
+++ b/src/libinjector/win/methods/win_terminate.c
@@ -101,15 +101,11 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
 
             PRINT_DEBUG("Process %d terminated successfully!\n", injector->terminate_pid);
 
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP4:
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -123,11 +119,16 @@ event_response_t handle_win_terminate(drakvuf_t drakvuf, drakvuf_trap_info_t* in
 
 static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
 {
+    drakvuf_t drakvuf = injector->drakvuf;
+
     PRINT_DEBUG("Exiting prematurely\n");
 
     if (injector->rc == INJECTOR_SUCCEEDED)
         injector->rc = INJECTOR_FAILED;
 
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP4, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }

--- a/src/libinjector/win/methods/win_write_file.c
+++ b/src/libinjector/win/methods/win_write_file.c
@@ -253,19 +253,14 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
             if (is_fun_error(drakvuf, info, "Could not close File handle"))
                 return cleanup(injector, info);
 
-            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-
             PRINT_DEBUG("File operation executed OK\n");
             injector->rc = INJECTOR_SUCCEEDED;
 
-            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
-            break;
-        }
-        case STEP8: // exit loop
-        {
             drakvuf_remove_trap(drakvuf, info->trap, NULL);
             drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
-            event = VMI_EVENT_RESPONSE_NONE;
+
+            memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
+            event = VMI_EVENT_RESPONSE_SET_REGISTERS;
             break;
         }
         default:
@@ -280,9 +275,15 @@ event_response_t handle_writefile(drakvuf_t drakvuf, drakvuf_trap_info_t* info)
 
 static event_response_t cleanup(injector_t injector, drakvuf_trap_info_t* info)
 {
+    drakvuf_t drakvuf = injector->drakvuf;
+
     PRINT_DEBUG("Exiting prematurely\n");
+
+    drakvuf_remove_trap(drakvuf, info->trap, NULL);
+    drakvuf_interrupt(drakvuf, SIGDRAKVUFERROR);
+
     memcpy(info->regs, &injector->x86_saved_regs, sizeof(x86_registers_t));
-    return override_step(injector, STEP8, VMI_EVENT_RESPONSE_SET_REGISTERS);
+    return VMI_EVENT_RESPONSE_SET_REGISTERS;
 }
 
 static bool write_chunk_to_buffer(injector_t injector, x86_registers_t* regs, uint8_t* buf, size_t amount)


### PR DESCRIPTION
TODO: COMMIT MESSAGE

Tested on top of upstream commit 236b3e59d7942e4c91ef867edac12f5fe1a2004a.